### PR TITLE
Add support for no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ description = """Fastdivide is a partial port of libdivide. It makes it possible
 categories = ["database-implementations", "data-structures"]
 readme = "README.md"
 
+[lib]
+path = "src/lib.rs"
+
+[features]
+default = []
+std = []
+
 [dependencies]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,7 @@ description = """Fastdivide is a partial port of libdivide. It makes it possible
 categories = ["database-implementations", "data-structures"]
 readme = "README.md"
 
-[lib]
-path = "src/lib.rs"
-
 [features]
-default = []
 std = []
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,10 @@ fn histogram(vals: &[u64], min: u64, interval: u64, output: &mut [usize]) {
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
 // ported from  libdivide.h by ridiculous_fish
 //
 //  This file is not the original library, it is an attempt to port part

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,10 @@ fn histogram(vals: &[u64], min: u64, interval: u64, output: &mut [usize]) {
 ```
 
 */
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 // ported from  libdivide.h by ridiculous_fish
 //


### PR DESCRIPTION
This pull request adds support for `no_std` libraries, according to the best practices outlined here: https://doc.rust-lang.org/cargo/reference/features.html

As a consumer of this library, nothing will change. You can include it as normal. By adding the `#![no_std]` directive at the top, along with the `extern crate std;` it allows other `no_std` projects to include this library without causing build problems.

Similarly, if a project is a normal binary, the `extern crate std;` allows those project types to continue working as expected.

I've tested this with two projects. A no_std project and a normal binary project. It continues to function as expected. The tests also run successfully.

Any feedback is most welcome.

Thank you for putting together such a great crate! I hope this small contribution is helpful.