### PR TITLE
Add missing repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "zlib-acknowledgement"
 description = """Fastdivide is a partial port of libdivide. It makes it possible to reduce the cost of divisions."""
 categories = ["database-implementations", "data-structures"]
+repository = "https://github.com/fulmicoton/fastdivide"
 readme = "README.md"
 edition = "2018"
 


### PR DESCRIPTION
Hi! While scraping crates.io I've found this crate to be missing the `repository` field. This PR fixes it.